### PR TITLE
Complex function and natural exponential support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# VS code stuff
+.vscode/**
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 # Prony.jl
 Pure Julia package for oscillating exponential fitting. Use with caution. The numerics are badly conditioned if the number of points is large. Always check the results.
 
-[![Build status (Github Actions)](https://github.com/IlianPihlajamaa/Prony.jl/workflows/CI/badge.svg)](https://github.com/IlianPihlajamaa/Prony.jl/actions)
-[![codecov.io](http://codecov.io/github/IlianPihlajamaa/Prony.jl/coverage.svg?branch=main)](http://codecov.io/github/IlianPihlajamaa/Prony.jl?branch=main)
-
 This is a pure julia implementation of Prony's method. See for example:
 
 Fernández Rodríguez, A., de Santiago Rodrigo, L., López Guillén, E. et al. Coding Prony’s method in MATLAB and applying it to biomedical signal filtering. BMC Bioinformatics 19, 451 (2018). https://doi.org/10.1186/s12859-018-2473-y
@@ -15,7 +12,7 @@ The package exports an implementation of the standard Prony interpolation `prony
 
 It tries to find exponential amplitudes `A_j` and bases `B_j`, such that
 
-<img src="https://render.githubusercontent.com/render/math?math=y_i\approx \sum_{j=1}^{N} A_jB_j^{(i-1)}">
+$$y_i\approx \sum_{j=1}^{N} A_jB_j^{(i-1)}$$
 
 Note that these methods are unstable if the number of datapoints is very large.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $$y\approx\sum_{j=1}^{N} A_jB_j^{(N-1)(x-x_0)/(x_M-x_0)}$$
 
 Or in terms of decaying exponentials:
 
-$$y\approx\sum_{j=1}^N A_j \exp\left\{(x-x_0)\left[\frac{N-1}{x_M-x_0}\ln(B)\right]\right\}$$
+$$y\approx\sum_{j=1}^N A_j \exp\left((x-x_0)\left[\frac{N-1}{x_M-x_0}\ln(B)\right]\right)$$
 
 Note that these methods are unstable if the number of datapoints is very large.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ It tries to find exponential amplitudes `A_j` and bases `B_j`, such that
 
 $$y_i\approx \sum_{j=1}^{N} A_jB_j^{(i-1)}$$
 
+The resulting fit obtained is then of the form:
+
+$$y\approx\sum_{j=1}^{N} A_jB_j^{(N-1)(x-x_0)/(x_M-x_0)}$$
+
+Or in terms of decaying exponentials:
+
+$$y\approx\sum_{j=1}^N A_j \exp\left\{(x-x_0)\left[\frac{N-1}{x_M-x_0}\ln(B)\right]\right\}$$
+
 Note that these methods are unstable if the number of datapoints is very large.
 
 Usage:

--- a/src/Prony.jl
+++ b/src/Prony.jl
@@ -5,12 +5,34 @@ using PolynomialRoots, LinearAlgebra
 export prony
 export PronyMethod, ApproximatePronyMethod
 
-struct DampedCosineFit{T}
+# Fitting object returned by prony: 
+struct DampedCosineFit{T} 
     p::Int64
     x_array::Array{T,1}
-    y_array::Array{T,1}
+    y_array::Array{Complex{T},1}
+
+    # y = A*B^{ (x-x0)(N-1)/(xmax-xmin) }
     bases::Array{Complex{T}, 1}
     amplitudes::Array{Complex{T}, 1}
+end
+
+# Exponential version (equivalent)
+struct ComplexExponentialFit{T}
+    p::Int64
+    x_array::Array{T,1}
+    y_array::Array{Complex{T},1}
+
+    # y = A*exp(λ*(x-x0))
+    exponents::Array{Complex{T}, 1}
+    amplitudes::Array{Complex{T}, 1}
+end
+
+# Convert Damped Cosine to Exponential
+function exponentialVersion(fit::DampedCosineFit{T}) where T
+    N = length(fit.x_array)
+    Δ = fit.x_array[end] - fit.x_array[1]
+    exponents = ln.(fit.bases) * (N-1)/Δ
+    return ComplexExponentialFit(fit.p, fit.x_array, fit.y_array, exponents, fit.amplitudes)
 end
 
 struct PronyMethod end
@@ -27,12 +49,12 @@ function (fit::DampedCosineFit{T})(x::T) where T
     indx = (x-xmin)/(xmax-xmin)*(N-1)
     result = zero(T)
     for i = 1:round(Int64,fit.p)
-        result += real.(fit.amplitudes[i] * fit.bases[i]^indx)
+        result += (fit.amplitudes[i] * fit.bases[i]^indx)
     end
     return result
 end
 
-function construct_prediction_matrix(y, p)
+function construct_prediction_matrix(y, p)  # H_ij = y_{i+j+1}
     N = length(y)
     prediction_matrix = zeros(eltype(y), N-p, p)
     for row = 1:p
@@ -52,7 +74,7 @@ function construct_observation_vector(y, p)
     return observation_vector
 end
 
-function is_equidistant(x)
+function is_equidistant(x) # x input must be equidistant or code returns error
     N = length(x)
     dx = x[2] - x[1]
     for i = 2:N-1
@@ -115,7 +137,8 @@ function find_bases(y, p, ::PronyMethod)
     return polynomialroots
 end
 
-function prony(x::AbstractVector, y::AbstractVector, ::PronyMethod)
+# Prony method with length(x) exponentials
+function prony(x::AbstractVector, y::AbstractVector, ::PronyMethod; exponentialMode = false)
     if isodd(length(x))
         pop!(x)
         pop!(y)
@@ -124,13 +147,14 @@ function prony(x::AbstractVector, y::AbstractVector, ::PronyMethod)
     check_args(x, y, p)
     bases = find_bases(y, p, PronyMethod())
     amplitudes = find_amplitudes(bases, y, PronyMethod())
-    return DampedCosineFit(p, x, y, bases, amplitudes)
+
+    exponentialMode ?
+        (return exponentialVersion(DampedCosineFit(p, x, y, bases, amplitudes))) :
+        (return DampedCosineFit(p, x, y, bases, amplitudes))
 end
 
-function prony(x::AbstractVector, y::AbstractVector, M::Int64, m::ApproximatePronyMethod)
-    if !(eltype(y) <: Real)
-        error("ApproximateProny is not implemented for complex functions")
-    end
+# Prony method with M exponentials
+function prony(x::AbstractVector, y::AbstractVector, M::Int64, m::ApproximatePronyMethod; exponentialMode = false)
     if isodd(length(x))
         pop!(x)
         pop!(y)
@@ -153,24 +177,26 @@ function prony(x::AbstractVector, y::AbstractVector, M::Int64, m::ApproximatePro
     bases = bases[sortedindx]
     amplitudes = amplitudes[sortedindx]
 
-    return DampedCosineFit(length(bases), x, y, bases, amplitudes)
+    exponentialMode ? 
+        (return exponentialVersion(DampedCosineFit(length(bases), x, y, bases, amplitudes))) :
+        (return DampedCosineFit(length(bases), x, y, bases, amplitudes))
 end
 
 
-function prony(x::AbstractVector, y::AbstractVector, N::Int64; decay=false)
-    return prony(x, y, N, ApproximatePronyMethod(decay))
+function prony(x::AbstractVector, y::AbstractVector, N::Int64; decay=false, exponentialMode = false)
+    return prony(x, y, N, ApproximatePronyMethod(decay); exponentialMode = exponentialMode)
 end
 
-function prony(x::AbstractRange, y::AbstractVector, N::Int64; decay=false)
-    return prony(collect(x), y, N, ApproximatePronyMethod(decay))
+function prony(x::AbstractRange, y::AbstractVector, N::Int64; decay=false, exponentialMode = false)
+    return prony(collect(x), y, N, ApproximatePronyMethod(decay); exponentialMode = exponentialMode)
 end
 
-function prony(x::AbstractVector, y::AbstractVector)
-    return prony(x, y, PronyMethod())
+function prony(x::AbstractVector, y::AbstractVector; exponentialMode = false)
+    return prony(x, y, PronyMethod(); exponentialMode = exponentialMode)
 end
 
-function prony(x::AbstractRange, y::AbstractVector)
-    return prony(collect(x), y, PronyMethod())
+function prony(x::AbstractRange, y::AbstractVector; exponentialMode = false)
+    return prony(collect(x), y, PronyMethod(); exponentialMode = exponentialMode)
 end
 
 end # module

--- a/src/Prony.jl
+++ b/src/Prony.jl
@@ -31,7 +31,7 @@ end
 function exponentialVersion(fit::DampedCosineFit{T}) where T
     N = length(fit.x_array)
     Δ = fit.x_array[end] - fit.x_array[1]
-    exponents = ln.(fit.bases) * (N-1)/Δ
+    exponents = log.(fit.bases) * (N-1)/Δ
     return ComplexExponentialFit(fit.p, fit.x_array, fit.y_array, exponents, fit.amplitudes)
 end
 
@@ -50,6 +50,18 @@ function (fit::DampedCosineFit{T})(x::T) where T
     result = zero(T)
     for i = 1:round(Int64,fit.p)
         result += (fit.amplitudes[i] * fit.bases[i]^indx)
+    end
+    return result
+end
+
+function (fit::ComplexExponentialFit{T})(x::T) where T
+    xmin = fit.x_array[1]
+    xmax = fit.x_array[end]
+    N = length(fit.x_array)
+    indx = (x-xmin)
+    result = zero(T)
+    for i = 1:round(Int64,fit.p)
+        result += (fit.amplitudes[i] * exp(fit.exponents[i]*indx))
     end
     return result
 end

--- a/src/Prony.jl
+++ b/src/Prony.jl
@@ -161,8 +161,8 @@ function prony(x::AbstractVector, y::AbstractVector, ::PronyMethod; exponentialM
     amplitudes = find_amplitudes(bases, y, PronyMethod())
 
     exponentialMode ?
-        (return exponentialVersion(DampedCosineFit(p, x, y, bases, amplitudes))) :
-        (return DampedCosineFit(p, x, y, bases, amplitudes))
+        (return exponentialVersion(DampedCosineFit(p, x, Complex.(y), bases, amplitudes))) :
+        (return DampedCosineFit(p, x, Complex.(y), bases, amplitudes))
 end
 
 # Prony method with M exponentials
@@ -190,8 +190,8 @@ function prony(x::AbstractVector, y::AbstractVector, M::Int64, m::ApproximatePro
     amplitudes = amplitudes[sortedindx]
 
     exponentialMode ? 
-        (return exponentialVersion(DampedCosineFit(length(bases), x, y, bases, amplitudes))) :
-        (return DampedCosineFit(length(bases), x, y, bases, amplitudes))
+        (return exponentialVersion(DampedCosineFit(length(bases), x, Complex.(y), bases, amplitudes))) :
+        (return DampedCosineFit(length(bases), x, Complex.(y), bases, amplitudes))
 end
 
 


### PR DESCRIPTION
## Support for complex functions

The code as written almost supported complex functions anyway. The fitting already worked perfectly well; the `DampedCosineFit` structure needed a minor tweak and removing an error message in `prony(x, y, M)` method did not produce any downstream errors or fitting inaccuracies.

## Fitting with natural exponentials

I added a struct `ComplexExponentialFit` in the same style as `DampedCosineFit` which returns the fit as a set of amplitudes and exponents, rather than amplitudes and bases. I also added a function to easily convert between the two, and an optional bool `exponentialMode` which can be passed to any `prony` method; it is false by default and if set to true returns a `ComplexExponentialFit` rather than a `DampedCosineFit`.